### PR TITLE
Fix pressure units in parsing ThermoML

### DIFF
--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -140,6 +140,9 @@ class TestThermoMLDataset:
             for key in property1.keys():
                 assert property1[key] == property2[key]
 
+            # likely redundant
+            assert property1["pressure"] == property2["pressure"]
+
 
 @pytest.mark.skip(reason="Implement next")
 def test_load_single_osmotic():

--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -18,7 +18,7 @@ from dimsim.datasets.thermoml import ThermoMLDataSet
             {
                 "x": [1.0],
                 "temperature": 293.15,
-                "pressure": 101.325,
+                "pressure": 101.3,
                 "value": 0.96488,
                 "std": 0.00005,
                 "units": "g/mL",
@@ -92,7 +92,7 @@ class TestThermoMLDataset:
 
         assert entry["temperature"] == expected["temperature"]
         if expected["pressure"] is not None:
-            assert numpy.isclose(entry["pressure"], expected["pressure"], rtol=0.00025)
+            assert numpy.isclose(entry["pressure"], expected["pressure"], rtol=1e-8)
         else:
             assert entry["pressure"] is None
 

--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -18,7 +18,7 @@ from dimsim.datasets.thermoml import ThermoMLDataSet
             {
                 "x": [1.0],
                 "temperature": 293.15,
-                "pressure": 1.0,
+                "pressure": 101.325,
                 "value": 0.96488,
                 "std": 0.00005,
                 "units": "g/mL",
@@ -30,7 +30,7 @@ from dimsim.datasets.thermoml import ThermoMLDataSet
             {
                 "x": [0.219, 0.781],
                 "temperature": 298.15,
-                "pressure": 0.997,
+                "pressure": 101.0,
                 "value": 0.03021,
                 "std": 0.000151,
                 "units": "kcal/mol",
@@ -54,7 +54,7 @@ from dimsim.datasets.thermoml import ThermoMLDataSet
             {
                 "x": [1.0],
                 "temperature": 293.15,
-                "pressure": 0.997,
+                "pressure": 101.0,
                 "value": 11.76,
                 "std": 0.02,
                 "units": "dimensionless",
@@ -92,7 +92,7 @@ class TestThermoMLDataset:
 
         assert entry["temperature"] == expected["temperature"]
         if expected["pressure"] is not None:
-            assert numpy.isclose(entry["pressure"], expected["pressure"], atol=1e-3)
+            assert numpy.isclose(entry["pressure"], expected["pressure"], rtol=0.00025)
         else:
             assert entry["pressure"] is None
 

--- a/dimsim/datasets/thermoml.py
+++ b/dimsim/datasets/thermoml.py
@@ -2292,7 +2292,7 @@ def _standardize_pressure(pressure) -> float | None:
     if pressure is None:
         return None
     if isinstance(pressure, unit.Quantity):
-        return pressure.to("atmosphere").magnitude  # type: ignore[no-any-return]
+        return pressure.to("kPa").magnitude  # type: ignore[no-any-return]
     else:
         raise ValueError(f"Pressure {pressure} is not a valid type.")
 


### PR DESCRIPTION
Fixes #66

I don't care if we standardize on kPa or atmospheres, just that we're consistent. Or: if we want atmospheres, I'm happy to standardize on that

- [x] Add test roundtripping with Pandas (this test already existed)
- [x] Make sure this doesn't break anything parsing large file(s)