### PR TITLE
Warn, not error, when trying to store duplicate entries

### DIFF
--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -2,12 +2,51 @@ import uuid
 
 import numpy
 import pytest
-from openff.toolkit import Molecule
+from openff.toolkit import Molecule, Quantity
 from openff.toolkit.utils.toolkits import OPENEYE_AVAILABLE
 from openff.units import Unit
 
 from dimsim._tests.utils import get_test_data_path
-from dimsim.datasets.thermoml import DuplicateThermoMLEntryWarning, ThermoMLDataSet
+from dimsim.datasets.provenance import MeasurementSource
+from dimsim.datasets.thermoml import (
+    DuplicateThermoMLEntryWarning,
+    ThermoMLDataSet,
+    ThermoMLProperty,
+    _property_unit_map,
+    _tag_property_map,
+)
+from dimsim.substances import Component, Substance
+
+
+def data_entry_to_property_and_source(
+    entry: dict,
+) -> ThermoMLProperty:
+
+    property_ = ThermoMLProperty(type_string=_tag_property_map[entry["tag"]])
+    property_.default_unit = _property_unit_map[property_.type_string]
+
+    substance = Substance()
+
+    for smiles, x in zip(entry["smiles"], entry["x"]):
+        substance.add_component(
+            component=Component(smiles=smiles),
+            amount=x,
+        )
+
+    property_.substance = substance
+
+    property_.temperature = Quantity(entry["temperature"], "kelvin")
+    property_.pressure = Quantity(entry["pressure"], "kilopascal") if entry["pressure"] else None
+
+    unit_to_use = _property_unit_map[property_.type_string]
+
+    property_.value = Quantity(entry["value"], unit_to_use)
+    property_.uncertainty = Quantity(entry["std"], unit_to_use)
+
+    # if this was in production, need better way to determine if source is a DOI or not
+    property_.source = MeasurementSource(doi=entry["source"]) if entry["source"].startswith("10.") else None
+
+    return property_
 
 
 @pytest.mark.parametrize(
@@ -323,7 +362,7 @@ def test_thermoml_warn_duplicate_properties():
 @pytest.mark.filterwarnings("error")
 def test_thermoml_no_warning_for_slightly_different_properties():
 
-    property1 = {
+    original = {
         "id": 1,
         "tag": "density",
         "smiles": ["COCCO"],
@@ -336,29 +375,40 @@ def test_thermoml_no_warning_for_slightly_different_properties():
         "source": "10.61092/iaea.ght7-f9qq",  # this DOI is meaningless
     }
 
-    # for these properties, trust that ThermoMLProperty._get_property_hash accurately accounts for
-    # std, source, etc. being different. Going from entry (dict) to ThermoMLProperty (class) is
-    # non-trivial and not currently part of the API
-    property_lower_uncertainty = {
-        **property1,
+    lower_uncertainty = {
+        **original,
         "id": 2,
-        "std": property1["std"] * 0.99,
+        "std": original["std"] * 0.99,
     }
 
-    property_different_doi = {
-        **property1,
+    different_doi = {
+        **original,
         "id": 3,
         "source": "10.61092/iaea.ght7-f9qr",  # this DOI is also meaningless
     }
 
+    # ~roundtrip each through ThermoMLDataSet._property_to_entry to ensure the generated id
+    # is based on values of the property, not just set arbitrarily
+    entry1 = ThermoMLDataSet._property_to_entry(data_entry_to_property_and_source(original))
+
+    entry2 = ThermoMLDataSet._property_to_entry(data_entry_to_property_and_source(lower_uncertainty))
+
+    entry3 = ThermoMLDataSet._property_to_entry(data_entry_to_property_and_source(different_doi))
+
+    assert entry1["id"] != 1
+    assert entry2["id"] != 2
+    assert entry3["id"] != 3
+
     dataset1 = ThermoMLDataSet()
 
-    dataset1.add_properties(*[property1, property_lower_uncertainty])
+    # different uncertainties should each be added as separate entries
+    dataset1.add_properties(*[entry1, entry2])
 
     assert len(dataset1) == 2
 
     dataset2 = ThermoMLDataSet()
 
-    dataset2.add_properties(*[property1, property_different_doi])
+    # different DOIs should also end up as separate entries, even if otherwise identical
+    dataset2.add_properties(*[entry1, entry3])
 
     assert len(dataset2) == 2

--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -1,4 +1,4 @@
-import uuid
+import random
 
 import numpy
 import pytest
@@ -238,7 +238,7 @@ def test_to_pandas():
     thermoml_dataset = ThermoMLDataSet()
 
     density_entry = {
-        "id": int(str(uuid.uuid4()).replace("-", "")),
+        "id": random.randint(10**15, 10**16 - 1),  # random 16-digit integer
         "tag": "density",
         "x": [1.0],
         "smiles": ["[C:1]([O:5][C:3]([C:2]([O:4][H:13])([H:9])[H:10])([H:11])[H:12])([H:6])([H:7])[H:8]"],

--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -7,7 +7,7 @@ from openff.toolkit.utils.toolkits import OPENEYE_AVAILABLE
 from openff.units import Unit
 
 from dimsim._tests.utils import get_test_data_path
-from dimsim.datasets.thermoml import ThermoMLDataSet
+from dimsim.datasets.thermoml import DuplicateThermoMLEntryWarning, ThermoMLDataSet
 
 
 @pytest.mark.parametrize(
@@ -293,3 +293,72 @@ def test_thermoml_pyrrolidinone_tautomer_resolution_without_openeye():
                 found_lactim = True
     assert not found_lactam, "Lactam SMILES should not be found in any parsed substance"
     assert found_lactim, "Lactim SMILES not found in any parsed substance"
+
+
+def test_thermoml_warn_duplicate_properties():
+    dataset = ThermoMLDataSet()
+
+    property_ = {
+        "id": 35598034897404032129990573617925713559702236029053845170364984208600110431820,
+        "tag": "density",
+        "smiles": ["COCCO"],
+        "x": [1.0],
+        "temperature": 293.15,
+        "pressure": 101.3,
+        "value": 0.9648800000000002,
+        "std": 5.0000000000000016e-05,
+        "units": "gram / milliliter",
+        "source": "",
+    }
+
+    with pytest.warns(
+        DuplicateThermoMLEntryWarning,
+        match="35598034897404032129990573617925713559702236029053845170364984208600110431820",
+    ):
+        dataset.add_properties(*[property_, property_])
+
+    assert len(dataset) == 1
+
+
+@pytest.mark.filterwarnings("error")
+def test_thermoml_no_warning_for_slightly_different_properties():
+
+    property1 = {
+        "id": 1,
+        "tag": "density",
+        "smiles": ["COCCO"],
+        "x": [1.0],
+        "temperature": 293.15,
+        "pressure": 101.3,
+        "value": 0.9648800000000002,
+        "std": 5.0000000000000016e-05,
+        "units": "gram / milliliter",
+        "source": "10.61092/iaea.ght7-f9qq",  # this DOI is meaningless
+    }
+
+    # for these properties, trust that ThermoMLProperty._get_property_hash accurately accounts for
+    # std, source, etc. being different. Going from entry (dict) to ThermoMLProperty (class) is
+    # non-trivial and not currently part of the API
+    property_lower_uncertainty = {
+        **property1,
+        "id": 2,
+        "std": property1["std"] * 0.99,
+    }
+
+    property_different_doi = {
+        **property1,
+        "id": 3,
+        "source": "10.61092/iaea.ght7-f9qr",  # this DOI is also meaningless
+    }
+
+    dataset1 = ThermoMLDataSet()
+
+    dataset1.add_properties(*[property1, property_lower_uncertainty])
+
+    assert len(dataset1) == 2
+
+    dataset2 = ThermoMLDataSet()
+
+    dataset2.add_properties(*[property1, property_different_doi])
+
+    assert len(dataset2) == 2

--- a/dimsim/_tests/datasets/test_thermoml.py
+++ b/dimsim/_tests/datasets/test_thermoml.py
@@ -238,7 +238,7 @@ def test_to_pandas():
     thermoml_dataset = ThermoMLDataSet()
 
     density_entry = {
-        "id": str(uuid.uuid4()).replace("-", ""),
+        "id": int(str(uuid.uuid4()).replace("-", "")),
         "tag": "density",
         "x": [1.0],
         "smiles": ["[C:1]([O:5][C:3]([C:2]([O:4][H:13])([H:9])[H:10])([H:11])[H:12])([H:6])([H:7])[H:8]"],

--- a/dimsim/configs/targets/thermo.py
+++ b/dimsim/configs/targets/thermo.py
@@ -23,7 +23,7 @@ DATA_SCHEMA = pyarrow.schema(
 
 
 class DataEntry(typing.TypedDict):
-    id: str
+    id: int
 
     tag: str  # was previously EntryTag
 

--- a/dimsim/datasets/thermoml.py
+++ b/dimsim/datasets/thermoml.py
@@ -2209,9 +2209,12 @@ class ThermoMLDataSet(pydantic.BaseModel):
                     DuplicateThermoMLEntryWarning,
                 )
 
-            all_ids.add(entry["id"])
+                continue
 
-        self._properties.extend(entries)
+            all_ids.add(entry["id"])
+            print(all_ids)
+
+            self._properties.extend([entry])
 
     def to_pandas(self) -> pandas.DataFrame:
 

--- a/dimsim/datasets/thermoml.py
+++ b/dimsim/datasets/thermoml.py
@@ -1869,6 +1869,15 @@ class ThermoMLProperty:
         """
         unit_to_use = _property_unit_map[self.type_string]
 
+        if not self.source:
+            stringified_source = ""
+        elif self.source.doi is not None:
+            stringified_source = self.source.doi
+        elif self.source.reference is not None:
+            stringified_source = self.source.reference
+        else:
+            stringified_source = ""
+
         # Evaluator had a .metadata attribute which we don't have here
         obj = {
             "type": self.type_string,
@@ -1878,7 +1887,7 @@ class ThermoMLProperty:
             "pressure": _standardize_pressure(self.pressure),
             "value": self.value.m_as(unit_to_use),
             "std": self.uncertainty.m_as(unit_to_use) if self.uncertainty is not None else None,
-            "source": self.source,
+            "source": stringified_source,
         }
 
         serialized = json.dumps(obj, sort_keys=True)
@@ -2143,37 +2152,43 @@ class ThermoMLDataSet(pydantic.BaseModel):
                 )
 
             for measured_property in properties:
-                unit_to_use = _property_unit_map[measured_property.type_string]
+                measured_property.source = source
 
-                assert Unit(measured_property.default_unit).is_compatible_with(unit_to_use)  # type: ignore[attr-defined]
-
-                # Could wrap this into a Source.__repr__()? Kinda ugly ...
-                if source.doi is not None:
-                    stringified_source = source.doi
-                elif source.reference is not None:
-                    stringified_source = source.reference
-                else:
-                    stringified_source = ""
-
-                # https://github.com/openforcefield/openff-evaluator/blob/c9b55687be3381768d75afdea01e9e18b5a35fac/openff/evaluator/datasets/datasets.py#L105-L110
-                entry = DataEntry(
-                    id=measured_property._get_raw_property_hash(),
-                    tag=_property_tag_map[measured_property.type_string],
-                    smiles=[component.smiles for component in measured_property.substance.components],
-                    x=[value for value in measured_property.substance.amounts.values()],
-                    temperature=_standardize_temperature(measured_property.temperature),  # type: ignore[typeddict-item]
-                    pressure=_standardize_pressure(measured_property.pressure),  # type: ignore[typeddict-item]
-                    value=measured_property.value.m_as(unit_to_use),
-                    std=measured_property.uncertainty.m_as(unit_to_use)
-                    if measured_property.uncertainty is not None
-                    else None,
-                    units=unit_to_use,
-                    source=stringified_source,  # This is fragile, but really preferable for pyarrow compatiblity
-                )
+                entry = cls._property_to_entry(measured_property)  # , source)
 
                 return_value.add_properties(entry)
 
         return return_value
+
+    @staticmethod
+    def _property_to_entry(measured_property: ThermoMLProperty) -> DataEntry:
+        unit_to_use = _property_unit_map[measured_property.type_string]
+
+        assert Unit(measured_property.default_unit).is_compatible_with(unit_to_use)  # type: ignore[attr-defined]
+
+        # # Could wrap this into a Source.__repr__()? Kinda ugly ...
+        if measured_property.source is None:
+            stringified_source = ""
+        elif measured_property.source.doi is not None:
+            stringified_source = measured_property.source.doi
+        elif measured_property.source.reference is not None:
+            stringified_source = measured_property.source.reference
+        else:
+            stringified_source = ""
+
+        # https://github.com/openforcefield/openff-evaluator/blob/c9b55687be3381768d75afdea01e9e18b5a35fac/openff/evaluator/datasets/datasets.py#L105-L110
+        return DataEntry(
+            id=measured_property._get_raw_property_hash(),
+            tag=_property_tag_map[measured_property.type_string],
+            smiles=[component.smiles for component in measured_property.substance.components],
+            x=[value for value in measured_property.substance.amounts.values()],
+            temperature=_standardize_temperature(measured_property.temperature),  # type: ignore[typeddict-item]
+            pressure=_standardize_pressure(measured_property.pressure),  # type: ignore[typeddict-item]
+            value=measured_property.value.m_as(unit_to_use),
+            std=measured_property.uncertainty.m_as(unit_to_use) if measured_property.uncertainty is not None else None,
+            units=unit_to_use,
+            source=stringified_source,  # This is fragile, but really preferable for pyarrow compatiblity
+        )
 
     def add_properties(self, *entries, validate=True):
         """Adds a physical property to the data set.

--- a/dimsim/datasets/thermoml.py
+++ b/dimsim/datasets/thermoml.py
@@ -24,6 +24,11 @@ from dimsim.configs.targets.thermo import DataEntry
 from dimsim.datasets.phase import PropertyPhase
 from dimsim.datasets.provenance import MeasurementSource
 
+
+class DuplicateThermoMLEntryWarning(UserWarning):
+    """A warning raised when a ThermoML entry is found which appears to be a duplicate of another entry."""
+
+
 _property_tag_map = {
     "Excess molar enthalpy (molar enthalpy of mixing), kJ/mol": "ethalpy_of_mixing",
     "Relative permittivity at zero frequency": "dielectric_constant",
@@ -2190,7 +2195,19 @@ class ThermoMLDataSet(pydantic.BaseModel):
                 validate_entry(entry)
 
             if entry["id"] in all_ids:
-                raise KeyError(f"A property with the unique id {entry['id']} already exists.")
+                # See Issue #68, there is probably nothing wrong with duplicated entries, and probably
+                # no reason to store duplicates
+                #   * if properties are truly duplicate from the same source, just warn and move on (but
+                #         maybe deal with later in filterin)
+                #   * if otherwise-identical properties come from different sources, they will hash to
+                #         different ids and we shouldn't end up in this clause
+                #
+                # this is *not true* if important criteria are not included in the hash function that
+                # the id is set from
+                warnings.warn(
+                    f"A property with the unique id {entry['id']} already exists, so not adding it now.",
+                    DuplicateThermoMLEntryWarning,
+                )
 
             all_ids.add(entry["id"])
 

--- a/dimsim/datasets/thermoml.py
+++ b/dimsim/datasets/thermoml.py
@@ -2212,9 +2212,8 @@ class ThermoMLDataSet(pydantic.BaseModel):
                 continue
 
             all_ids.add(entry["id"])
-            print(all_ids)
 
-            self._properties.extend([entry])
+            self._properties.append(entry)
 
     def to_pandas(self) -> pandas.DataFrame:
 


### PR DESCRIPTION
A possible dead-simple solution to #68: just warn instead of error

- [ ] Add tests
  - [x] Parse a (small) dataset with duplicate entries, show duplicates not stored
  - [x] Test cases of near-duplicates
    - [x] Same property from different DOIs (should each be stored)
    - [x] Same property from one source but different uncertainties (should each be stored)
  - [x] Show that warning is raised
  - [ ] Show that warning can be turned off (?)